### PR TITLE
Add the query string parameter rest_total_hits_as_int=true to upstream requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ var createSearchkitRouter = function(config) {
   }
   router.post("/_search", function(req, res){
     var queryBody = config.queryProcessor(req.body || {}, req, res)
-    elasticRequest("/_search", queryBody).pipe(res)
+    elasticRequest("/_search?rest_total_hits_as_int=true", queryBody).pipe(res)
   });
 
   return router


### PR DESCRIPTION
This is required to make the searchkit UI components work with Elasticsearch 7.4